### PR TITLE
Allow Extensibility To Other Serializers

### DIFF
--- a/UnboxedAlamofire.podspec
+++ b/UnboxedAlamofire.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author = { "Serhii Butenko" => "sereja.butenko@gmail.com" }
   s.source = { :git => 'https://github.com/serejahh/UnboxedAlamofire.git', :tag => s.version }
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'

--- a/UnboxedAlamofire.xcodeproj/project.pbxproj
+++ b/UnboxedAlamofire.xcodeproj/project.pbxproj
@@ -630,7 +630,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -677,7 +677,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -705,7 +705,7 @@
 				);
 				INFOPLIST_FILE = UnboxedAlamofire/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.UnboxedAlamofire;
 				PRODUCT_NAME = UnboxedAlamofire;
@@ -730,7 +730,7 @@
 				);
 				INFOPLIST_FILE = UnboxedAlamofire/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.UnboxedAlamofire;
 				PRODUCT_NAME = UnboxedAlamofire;

--- a/UnboxedAlamofire/UnboxedAlamofire.swift
+++ b/UnboxedAlamofire/UnboxedAlamofire.swift
@@ -26,7 +26,7 @@ extension DataRequest {
      */
     @discardableResult
     public func responseObject<T: Unboxable>(queue: DispatchQueue? = nil, keyPath: String? = nil, options: JSONSerialization.ReadingOptions = .allowFragments, completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
-        return response(queue: queue, responseSerializer: DataRequest.serializeUnboxResponseObject(options: options, keyPath: keyPath), completionHandler: completionHandler)
+        return response(queue: queue, responseSerializer: DataRequest.unboxObjectResponseSerializer(options: options, keyPath: keyPath), completionHandler: completionHandler)
     }
     
     /**
@@ -41,7 +41,7 @@ extension DataRequest {
      */
     @discardableResult
     public func responseArray<T: Unboxable>(queue: DispatchQueue? = nil, keyPath: String? = nil, options: JSONSerialization.ReadingOptions = .allowFragments, completionHandler: @escaping (DataResponse<[T]>) -> Void) -> Self {
-        return response(queue: queue, responseSerializer: DataRequest.serializeUnboxResponseArray(options: options, keyPath: keyPath), completionHandler: completionHandler)
+        return response(queue: queue, responseSerializer: DataRequest.unboxArrayResponseSerializer(options: options, keyPath: keyPath), completionHandler: completionHandler)
     }
 }
 

--- a/UnboxedAlamofire/UnboxedAlamofire.swift
+++ b/UnboxedAlamofire/UnboxedAlamofire.swift
@@ -57,7 +57,7 @@ extension DataRequest {
      */
     public static func unboxObjectResponseSerializer<T: Unboxable>(options: JSONSerialization.ReadingOptions = .allowFragments, keyPath:String?) -> DataResponseSerializer<T> {
         return DataResponseSerializer { _, response, data, error in
-            return Request.serializeUnboxResponseObject(options: options, keyPath: keyPath, response: response, data: data, error: error)
+            return Request.serializeUnboxObjectResponse(options: options, keyPath: keyPath, response: response, data: data, error: error)
         }
     }
     
@@ -71,7 +71,7 @@ extension DataRequest {
      */
     public static func unboxArrayResponseSerializer<T: Unboxable>(options: JSONSerialization.ReadingOptions = .allowFragments, keyPath:String?) -> DataResponseSerializer<[T]> {
         return DataResponseSerializer { _, response, data, error in
-            return Request.serializeUnboxResponseArray(options: options, keyPath: keyPath, response: response, data: data, error: error)
+            return Request.serializeUnboxArrayResponse(options: options, keyPath: keyPath, response: response, data: data, error: error)
         }
     }
 }
@@ -89,7 +89,7 @@ extension Request {
      
      - returns: The result data type.
      */
-    public static func serializeUnboxResponseObject<T: Unboxable>(options: JSONSerialization.ReadingOptions, keyPath:String?, response: HTTPURLResponse?, data: Data?, error: Error?) -> Result<T> {
+    public static func serializeUnboxObjectResponse<T: Unboxable>(options: JSONSerialization.ReadingOptions, keyPath:String?, response: HTTPURLResponse?, data: Data?, error: Error?) -> Result<T> {
         if let error = error {
             return .failure(error)
         }
@@ -128,7 +128,7 @@ extension Request {
      
      - returns: The result data type.
      */
-    public static func serializeUnboxResponseArray<T: Unboxable>(options: JSONSerialization.ReadingOptions, keyPath:String?, response: HTTPURLResponse?, data: Data?, error: Error?) -> Result<[T]> {
+    public static func serializeUnboxArrayResponse<T: Unboxable>(options: JSONSerialization.ReadingOptions, keyPath:String?, response: HTTPURLResponse?, data: Data?, error: Error?) -> Result<[T]> {
         if let error = error {
             return .failure(error)
         }


### PR DESCRIPTION
Mainly just some rearranging of code. Modeling the serializer more closely to the structure of the JSON serializer. The main motivation is so that other developers can use the core unboxing serializer in their custom response serializers.